### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test and Coverage
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bnbong/FastAPI-fastkit/security/code-scanning/5](https://github.com/bnbong/FastAPI-fastkit/security/code-scanning/5)

The optimal fix is to add the `permissions` key to the workflow file, specifying the principle of least privilege. For most CI workflows, `contents: read` is sufficient unless writing to the repository or managing issues/pull-requests. In this case, since the steps involve checking out code, running tests, and uploading coverage information (to Codecov, an external service, not GitHub), `contents: read` is likely sufficient. If in the future you need to interact with issues, pull requests, or other resources, you can extend with those granular permissions. The change should be applied at the root level of the workflow for clarity and maintainability. The edit is to insert the following lines after `name: Test and Coverage` in .github/workflows/test.yml:

```yaml
permissions:
  contents: read
```

No additional methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
