### PR TITLE
[FEAT] enhance FastAPI-fastkit project templates and detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.3.0 (Unreleased)
+
+### Maintenances
+
+- **Modernize template contract to be pyproject-first** (#42)
+  - Template inspection now accepts `pyproject.toml-tpl` (PEP 621) as the primary metadata file. A template passes structural validation as long as `tests/`, `README.md-tpl`, and **at least one** of `pyproject.toml-tpl` / `setup.py-tpl` are present. `requirements.txt-tpl` is no longer strictly required when `pyproject.toml-tpl` declares `[project].dependencies`.
+  - `_check_dependencies` consults every available source (`requirements.txt-tpl`, `pyproject.toml-tpl` `[project].dependencies`, `setup.py-tpl` `install_requires`) independently and passes if **any** one declares `fastapi`. A template with a stale `requirements.txt-tpl` is no longer rejected when its `pyproject.toml-tpl` is authoritative.
+  - `read_template_stack` gained a pyproject fallback between the existing `requirements.txt-tpl` and `setup.py-tpl` paths; legacy templates resolve dependencies exactly as before.
+  - Template authoring docs (`src/fastapi_fastkit/fastapi_project_template/README.md`, `docs/en/contributing/template-creation-guide.md`, `docs/en/reference/template-quality-assurance.md`) now describe required vs optional files under the pyproject-first contract.
+  - Added focused tests for the new rules (pyproject-only structural and dependency validation, setup.py-only legacy validation, pyproject fallback in `read_template_stack`, and `requirements.txt-tpl`-over-pyproject precedence).
+- **Pyproject-aware project identity detection** (follow-up to #42)
+  - `is_fastkit_project()` now recognises FastAPI-fastkit-managed projects from `pyproject.toml` in addition to legacy `setup.py`. Detection precedence: `[tool.fastapi-fastkit].managed = true` → `[project].description` contains the `[FastAPI-fastkit templated]` marker (case-insensitive) → `setup.py` contains `fastapi-fastkit` (case-insensitive). Keeps the pre-existing setup.py path working; the new pyproject paths prevent pyproject-only templates from being mistaken for unrelated FastAPI projects in the user's workspace.
+  - Canonical marker strings (`[FastAPI-fastkit templated]` and the `[tool.fastapi-fastkit]` table key `fastapi-fastkit`) are exported from `fastapi_fastkit.utils.main` as `FASTKIT_DESCRIPTION_MARKER` / `FASTKIT_TOOL_SECTION` so templates, metadata injection, and detection all reference the same strings.
+  - `_process_pyproject_file` idempotently ensures the description marker and `[tool.fastapi-fastkit]\nmanaged = true` section are present after placeholder replacement, providing a safety net when a template author forgets to include them.
+  - All 8 shipped `pyproject.toml-tpl` templates updated to carry `description = "[FastAPI-fastkit templated] <description>"` and a `[tool.fastapi-fastkit]` table with `managed = true`.
+
 ## v1.2.1 (2026-04-17)
 
 ### Fixes

--- a/docs/en/contributing/template-creation-guide.md
+++ b/docs/en/contributing/template-creation-guide.md
@@ -96,13 +96,28 @@ fastapi-{template-name}/
 │   ├── lint.sh-tpl             # Linting
 │   ├── run-server.sh-tpl       # Server execution
 │   └── test.sh-tpl             # Test execution
-├── requirements.txt-tpl         # ✅ Dependencies (required)
-├── setup.py-tpl                # ✅ Package setup (required)
+├── pyproject.toml-tpl           # ✅ Primary metadata (PEP 621, preferred)
+├── setup.py-tpl                # 🟡 Legacy metadata (accepted for back-compat)
+├── requirements.txt-tpl         # 🟡 Optional when pyproject declares deps
 ├── setup.cfg-tpl               # Development tools configuration
 ├── README.md-tpl               # ✅ Project documentation (required)
 ├── .env-tpl                    # Environment variables template
 └── .gitignore-tpl              # Git ignore file
 ```
+
+**Minimum required files.** A template must provide:
+
+- `tests/` directory
+- `README.md-tpl`
+- At least one metadata file: `pyproject.toml-tpl` (preferred, PEP 621) or
+  `setup.py-tpl` (legacy, still accepted)
+- A declaration of `fastapi` as a dependency in at least one of:
+  `pyproject.toml-tpl` `[project].dependencies`, `requirements.txt-tpl`, or
+  `setup.py-tpl` `install_requires`
+
+`requirements.txt-tpl` is no longer strictly required when `pyproject.toml-tpl`
+declares `[project].dependencies`. Modern templates SHOULD adopt
+`pyproject.toml-tpl` as their primary metadata file.
 
 ### File Writing Guide
 
@@ -154,7 +169,58 @@ if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)
 ```
 
-#### 2. Writing requirements.txt-tpl
+#### 2. Writing pyproject.toml-tpl (preferred)
+
+Modern templates should declare metadata and dependencies with a PEP 621
+`pyproject.toml-tpl`. At minimum the file must expose a `[project]` section with
+`name`, `version`, a `description`, and a `dependencies` list that includes
+`fastapi`. Templates must also carry two FastAPI-fastkit identity markers so
+`is_fastkit_project()` can tell generated projects apart from unrelated FastAPI
+projects in the user's workspace:
+
+- `[FastAPI-fastkit templated]` prefix in `description`
+- A dedicated `[tool.fastapi-fastkit]` table with `managed = true`
+
+Detection accepts either marker (matching is case-insensitive). Metadata
+injection will add both at project generation time if a template omits them,
+but authors should include them explicitly.
+
+```toml
+[project]
+name = "<project_name>"
+version = "0.1.0"
+description = "[FastAPI-fastkit templated] <description>"
+authors = [
+    {name = "<author>", email = "<author_email>"},
+]
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "pydantic>=2.10.0",
+    "pydantic-settings>=2.7.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "httpx>=0.28.0",
+]
+
+[tool.fastapi-fastkit]
+managed = true
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+#### 3. Writing requirements.txt-tpl (optional)
+
+Optional when `pyproject.toml-tpl` declares `[project].dependencies`. Still
+useful for templates that prefer `pip`-only workflows.
 
 ```txt
 # FastAPI core dependencies (required)
@@ -183,7 +249,10 @@ isort==5.12.0
 mypy==1.7.1
 ```
 
-#### 3. Writing setup.py-tpl
+#### 4. Writing setup.py-tpl (legacy — optional when pyproject is present)
+
+Retained for legacy templates. New templates do not need this file if they
+ship `pyproject.toml-tpl`.
 
 ```python
 """
@@ -205,7 +274,7 @@ install_requires: list[str] = [
 setup(
     name="<project_name>",
     version="1.0.0",
-    description="[fastapi-fastkit templated] <description>",  # Required keyword
+    description="[FastAPI-fastkit templated] <description>",  # Identity marker used by is_fastkit_project()
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     author="<author>",
@@ -227,7 +296,7 @@ setup(
 )
 ```
 
-#### 4. Writing Test Files
+#### 5. Writing Test Files
 
 ```python
 # tests/test_items.py-tpl
@@ -299,9 +368,9 @@ The inspector automatically validates the following items:
 #### ✅ File Structure Validation
 
 - [ ] `tests/` directory exists
-- [ ] `requirements.txt-tpl` file exists
-- [ ] `setup.py-tpl` file exists
 - [ ] `README.md-tpl` file exists
+- [ ] At least one of `pyproject.toml-tpl` (preferred) or `setup.py-tpl`
+      (legacy) exists
 
 #### ✅ File Extension Validation
 
@@ -310,9 +379,10 @@ The inspector automatically validates the following items:
 
 #### ✅ Dependencies Validation
 
-- [ ] `requirements.txt-tpl` includes `fastapi`
-- [ ] `setup.py-tpl`'s `install_requires` includes `fastapi`
-- [ ] `setup.py-tpl`'s description includes `[fastapi-fastkit templated]`
+- [ ] `fastapi` is declared in at least one of:
+  - [ ] `pyproject.toml-tpl` under `[project].dependencies` (preferred)
+  - [ ] `requirements.txt-tpl`
+  - [ ] `setup.py-tpl` under `install_requires`
 
 #### ✅ FastAPI Implementation Validation
 

--- a/docs/en/reference/template-quality-assurance.md
+++ b/docs/en/reference/template-quality-assurance.md
@@ -188,13 +188,33 @@ For a template to pass inspection, it must meet these requirements:
 ### File Structure
 - Must contain a `src/` directory with Python source files
 - Python files must use `.py-tpl` extension
-- Must include a `requirements.txt-tpl` file
-- Must include a `setup.py-tpl` file
+- Must include a `tests/` directory and a `README.md-tpl` file
+- Must include **at least one** metadata file:
+  - `pyproject.toml-tpl` (preferred, PEP 621), or
+  - `setup.py-tpl` (legacy, still accepted)
+- `requirements.txt-tpl` is optional when `pyproject.toml-tpl` declares
+  `[project].dependencies`
 
 ### FastAPI Requirements
 - Must contain FastAPI app initialization
-- Must include proper dependency declarations
+- Must declare `fastapi` as a dependency in at least one of
+  `pyproject.toml-tpl` `[project].dependencies`, `requirements.txt-tpl`, or
+  `setup.py-tpl` `install_requires`
 - Must have valid Python syntax in all template files
+
+### Identity Markers
+Templates should carry FastAPI-fastkit identity markers so generated projects
+are distinguishable from unrelated FastAPI projects in the user's workspace:
+
+- `pyproject.toml-tpl` — both a `[FastAPI-fastkit templated]` prefix in
+  `description` and a `[tool.fastapi-fastkit]` table with `managed = true`.
+- `setup.py-tpl` — `[FastAPI-fastkit templated]` prefix in the `description`
+  argument to `setup()`.
+
+`is_fastkit_project()` accepts any one of these (pyproject takes precedence,
+setup.py is the legacy fallback; matching is case-insensitive). Metadata
+injection ensures the markers end up in generated projects even if a template
+forgets them.
 
 ### Quality Standards
 - All template files must be syntactically correct

--- a/scripts/inspect-changed-templates.py
+++ b/scripts/inspect-changed-templates.py
@@ -8,11 +8,13 @@ import sys
 from pathlib import Path
 from typing import List, Set
 
-from fastapi_fastkit.backend.inspector import inspect_fastapi_template
-
-# Ensure src is importable
+# Ensure src is importable before importing the package. Pre-commit / local
+# runs invoke this script with the project not installed in the interpreter,
+# so the sys.path bootstrap has to happen first.
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from fastapi_fastkit.backend.inspector import inspect_fastapi_template  # noqa: E402
 
 TEMPLATE_DIR = PROJECT_ROOT / "src" / "fastapi_fastkit" / "fastapi_project_template"
 

--- a/scripts/inspect-changed-templates.py
+++ b/scripts/inspect-changed-templates.py
@@ -8,11 +8,11 @@ import sys
 from pathlib import Path
 from typing import List, Set
 
+from fastapi_fastkit.backend.inspector import inspect_fastapi_template
+
 # Ensure src is importable
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
-
-from fastapi_fastkit.backend.inspector import inspect_fastapi_template
 
 TEMPLATE_DIR = PROJECT_ROOT / "src" / "fastapi_fastkit" / "fastapi_project_template"
 

--- a/scripts/inspect-templates.py
+++ b/scripts/inspect-templates.py
@@ -17,11 +17,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
+from fastapi_fastkit.backend.inspector import inspect_fastapi_template
+
 # Add src to path to import fastapi_fastkit modules
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
-
-from fastapi_fastkit.backend.inspector import inspect_fastapi_template
 
 
 def get_templates_to_inspect(specific_templates: str = "") -> List[str]:
@@ -119,7 +119,7 @@ def main() -> None:
     print(f"📋 Found {len(templates)} templates to inspect: {', '.join(templates)}")
     if args.verbose:
         print(f"🔧 Working directory: {os.getcwd()}")
-        print(f"📁 Template directory: src/fastapi_fastkit/fastapi_project_template/")
+        print("📁 Template directory: src/fastapi_fastkit/fastapi_project_template/")
     print("=" * 60)
 
     # Inspect each template

--- a/scripts/inspect-templates.py
+++ b/scripts/inspect-templates.py
@@ -17,11 +17,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
-from fastapi_fastkit.backend.inspector import inspect_fastapi_template
-
-# Add src to path to import fastapi_fastkit modules
+# Add src to path to import fastapi_fastkit modules. The sys.path bootstrap
+# must run before importing the package so the script works from a fresh
+# repo checkout without the package installed on the interpreter.
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
+
+from fastapi_fastkit.backend.inspector import inspect_fastapi_template  # noqa: E402
 
 
 def get_templates_to_inspect(specific_templates: str = "") -> List[str]:

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -302,7 +302,7 @@ Provide only the translated text without any additional commentary."""
     def translate(self, text: str, target_lang: str, source_lang: str = "en") -> str:
         """Translate text, automatically chunking if necessary."""
         try:
-            import openai
+            import openai  # noqa
         except ImportError:
             logger.error("OpenAI package not installed. Run: pip install openai")
             raise
@@ -316,7 +316,7 @@ Provide only the translated text without any additional commentary."""
                 raise
 
             # If payload too large, split into chunks and translate each
-            logger.info(f"Document too large, splitting into chunks for translation...")
+            logger.info("Document too large, splitting into chunks for translation...")
             chunks = self._split_text_into_chunks(text)
             logger.info(f"Split into {len(chunks)} chunks")
 

--- a/src/fastapi_fastkit/backend/inspector.py
+++ b/src/fastapi_fastkit/backend/inspector.py
@@ -23,19 +23,23 @@ import os
 import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import yaml
 
 from fastapi_fastkit.backend.main import (
+    _parse_setup_dependencies,
     create_venv,
     find_template_core_modules,
     inject_project_metadata,
     install_dependencies_with_manager,
 )
+from fastapi_fastkit.backend.package_managers.poetry_manager import (
+    _parse_pip_requirement,
+)
 from fastapi_fastkit.backend.transducer import copy_and_convert_template
-from fastapi_fastkit.core.settings import settings
 from fastapi_fastkit.utils.logging import debug_log, get_logger
 from fastapi_fastkit.utils.main import print_error, print_success, print_warning
 
@@ -127,7 +131,6 @@ class TemplateInspector:
 
     def _force_cleanup_directory(self, directory_path: str) -> None:
         """Force cleanup of directory with multiple strategies."""
-        import stat
         import time
 
         max_retries = 5
@@ -396,20 +399,39 @@ class TemplateInspector:
         return True
 
     def _check_file_structure(self) -> bool:
-        """Check the required file and directory structure."""
-        required_paths = [
-            "tests",
-            "requirements.txt-tpl",
-            "setup.py-tpl",
-            "README.md-tpl",
-        ]
+        """Check the required file and directory structure.
 
-        for path in required_paths:
-            if not (self.template_path / path).exists():
+        Modern templates may ship ``pyproject.toml-tpl`` as the primary metadata
+        file; ``setup.py-tpl`` remains accepted for backward compatibility.
+        A template must provide at least one of the two. ``requirements.txt-tpl``
+        is no longer strictly required when ``pyproject.toml-tpl`` declares
+        ``[project].dependencies``.
+        """
+        always_required = ["tests", "README.md-tpl"]
+        metadata_candidates = ["pyproject.toml-tpl", "setup.py-tpl"]
+
+        missing_required = [
+            path for path in always_required if not (self.template_path / path).exists()
+        ]
+        has_metadata = any(
+            (self.template_path / name).exists() for name in metadata_candidates
+        )
+
+        if missing_required:
+            for path in missing_required:
                 error_msg = f"Missing required path: {path}"
                 self.errors.append(error_msg)
                 debug_log(f"File structure check failed: {error_msg}", "error")
-                return False
+        if not has_metadata:
+            error_msg = (
+                "Missing metadata file: expected pyproject.toml-tpl "
+                "(preferred) or setup.py-tpl"
+            )
+            self.errors.append(error_msg)
+            debug_log(f"File structure check failed: {error_msg}", "error")
+
+        if missing_required or not has_metadata:
+            return False
 
         debug_log("File structure check passed", "info")
         return True
@@ -427,39 +449,138 @@ class TemplateInspector:
         return True
 
     def _check_dependencies(self) -> bool:
-        """Check the dependencies in both setup.py-tpl and requirements.txt-tpl."""
+        """Check that FastAPI is declared in at least one supported source.
+
+        All three metadata sources are consulted independently:
+
+        - ``requirements.txt-tpl``
+        - ``pyproject.toml-tpl`` ``[project].dependencies``
+        - ``setup.py-tpl`` ``install_requires``
+
+        The check passes if *any* source declares ``fastapi``, so a template
+        with a stale ``requirements.txt-tpl`` still passes when
+        ``pyproject.toml-tpl`` is authoritative. It fails only when every
+        present source is missing ``fastapi`` (or when no source exists at
+        all — that also implies no metadata file, which
+        ``_check_file_structure`` already rejects).
+        """
         req_path = self.template_path / "requirements.txt-tpl"
+        pyproject_path = self.template_path / "pyproject.toml-tpl"
         setup_path = self.template_path / "setup.py-tpl"
 
-        if not req_path.exists():
-            error_msg = "requirements.txt-tpl not found"
-            self.errors.append(error_msg)
-            debug_log(f"Dependencies check failed: {error_msg}", "error")
-            return False
-        if not setup_path.exists():
-            error_msg = "setup.py-tpl not found"
+        sources_checked: List[str] = []
+        fastapi_declared = False
+
+        if req_path.exists():
+            sources_checked.append("requirements.txt-tpl")
+            try:
+                with open(req_path, encoding="utf-8") as f:
+                    deps = f.read().splitlines()
+                package_names = {
+                    _parse_pip_requirement(dep)[0].lower()
+                    for dep in deps
+                    if dep.strip() and not dep.strip().startswith("#")
+                }
+                debug_log(
+                    f"requirements.txt-tpl dependencies: {sorted(package_names)}",
+                    "debug",
+                )
+                if "fastapi" in package_names:
+                    fastapi_declared = True
+            except (OSError, UnicodeDecodeError) as e:
+                error_msg = f"Error reading requirements.txt-tpl: {e}"
+                self.errors.append(error_msg)
+                debug_log(f"Dependencies check failed: {error_msg}", "error")
+                return False
+
+        if pyproject_path.exists():
+            sources_checked.append("pyproject.toml-tpl")
+            package_names, parse_error = self._extract_pyproject_dependency_names(
+                pyproject_path
+            )
+            if parse_error is not None:
+                self.errors.append(parse_error)
+                debug_log(f"Dependencies check failed: {parse_error}", "error")
+                return False
+            debug_log(
+                f"pyproject.toml-tpl dependencies: {sorted(package_names)}", "debug"
+            )
+            if "fastapi" in package_names:
+                fastapi_declared = True
+
+        if setup_path.exists():
+            sources_checked.append("setup.py-tpl")
+            try:
+                with open(setup_path, encoding="utf-8") as f:
+                    content = f.read()
+                deps = _parse_setup_dependencies(content)
+                package_names = {
+                    _parse_pip_requirement(dep)[0].lower() for dep in deps if dep
+                }
+                debug_log(
+                    f"setup.py-tpl dependencies: {sorted(package_names)}", "debug"
+                )
+                if "fastapi" in package_names:
+                    fastapi_declared = True
+            except (OSError, UnicodeDecodeError) as e:
+                error_msg = f"Error reading setup.py-tpl: {e}"
+                self.errors.append(error_msg)
+                debug_log(f"Dependencies check failed: {error_msg}", "error")
+                return False
+
+        if not sources_checked:
+            error_msg = (
+                "No dependency source found: expected one of requirements.txt-tpl, "
+                "pyproject.toml-tpl, or setup.py-tpl"
+            )
             self.errors.append(error_msg)
             debug_log(f"Dependencies check failed: {error_msg}", "error")
             return False
 
-        try:
-            with open(req_path, encoding="utf-8") as f:
-                deps = f.read().splitlines()
-                package_names = [dep.split("==")[0] for dep in deps if dep]
-                debug_log(f"Found dependencies: {package_names}", "debug")
-                if "fastapi" not in package_names:
-                    error_msg = "FastAPI dependency not found in requirements.txt-tpl"
-                    self.errors.append(error_msg)
-                    debug_log(f"Dependencies check failed: {error_msg}", "error")
-                    return False
-        except (OSError, UnicodeDecodeError) as e:
-            error_msg = f"Error reading requirements.txt-tpl: {e}"
+        if not fastapi_declared:
+            error_msg = (
+                "FastAPI dependency not found in any source ("
+                + ", ".join(sources_checked)
+                + ")"
+            )
             self.errors.append(error_msg)
             debug_log(f"Dependencies check failed: {error_msg}", "error")
             return False
 
-        debug_log("Dependencies check passed", "info")
+        debug_log(
+            f"Dependencies check passed (sources: {', '.join(sources_checked)})",
+            "info",
+        )
         return True
+
+    @staticmethod
+    def _extract_pyproject_dependency_names(
+        pyproject_path: Path,
+    ) -> Tuple[set, Optional[str]]:  # type: ignore
+        """Parse a pyproject.toml-tpl and return (lowercased dep names, error).
+
+        ``error`` is ``None`` on success. Returns an empty set with a descriptive
+        error string when the file is unreadable or malformed.
+        """
+        try:
+            with open(pyproject_path, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
+            return set(), f"Invalid pyproject.toml-tpl: {e}"
+
+        project = data.get("project", {})
+        raw_deps = project.get("dependencies", []) or []
+        if not isinstance(raw_deps, list):
+            return set(), "pyproject.toml-tpl [project].dependencies must be a list"
+
+        names: set = set()  # type: ignore
+        for dep in raw_deps:
+            if not isinstance(dep, str) or not dep.strip():
+                continue
+            name = _parse_pip_requirement(dep)[0]
+            if name:
+                names.add(name.lower())
+        return names, None
 
     def _check_fastapi_implementation(self) -> bool:
         """Check if the template has a proper FastAPI server implementation."""

--- a/src/fastapi_fastkit/backend/interactive/prompts.py
+++ b/src/fastapi_fastkit/backend/interactive/prompts.py
@@ -15,7 +15,6 @@
 from typing import Any, Dict, List, Optional, cast
 
 import click
-from rich.panel import Panel
 
 from fastapi_fastkit.utils.main import console, print_error
 

--- a/src/fastapi_fastkit/backend/main.py
+++ b/src/fastapi_fastkit/backend/main.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 import os
 import re
+import tomllib
 from typing import Dict, List
 
 import click
@@ -18,8 +19,9 @@ from fastapi_fastkit.core.exceptions import BackendExceptions
 from fastapi_fastkit.core.settings import settings
 from fastapi_fastkit.utils.logging import debug_log, get_logger
 from fastapi_fastkit.utils.main import (
+    FASTKIT_DESCRIPTION_MARKER,
+    FASTKIT_TOOL_SECTION,
     handle_exception,
-    print_error,
     print_info,
     print_success,
     print_warning,
@@ -82,12 +84,19 @@ def find_template_core_modules(project_dir: str) -> Dict[str, str]:
 
 def read_template_stack(template_path: str) -> List[str]:
     """
-    Read dependencies from template requirements.txt-tpl file or setup.py-tpl file.
+    Read dependencies from a template's metadata files.
+
+    Lookup order preserves legacy behaviour for templates that still ship
+    ``requirements.txt-tpl`` while allowing modern pyproject-first templates
+    to resolve their stack from ``pyproject.toml-tpl``:
+
+    1. ``requirements.txt-tpl`` (legacy, highest precedence)
+    2. ``pyproject.toml-tpl`` ``[project].dependencies``
+    3. ``setup.py-tpl`` ``install_requires``
 
     :param template_path: Path to the template directory
-    :return: List of dependencies
+    :return: List of PEP 508 requirement strings
     """
-    # First try requirements.txt-tpl
     req_file = os.path.join(template_path, "requirements.txt-tpl")
     if os.path.exists(req_file):
         try:
@@ -100,7 +109,12 @@ def read_template_stack(template_path: str) -> List[str]:
             )
             return []
 
-    # Fallback: try to read from setup.py-tpl for legacy templates
+    pyproject_file = os.path.join(template_path, "pyproject.toml-tpl")
+    if os.path.exists(pyproject_file):
+        deps = _parse_pyproject_dependencies(pyproject_file)
+        if deps:
+            return deps
+
     setup_file = os.path.join(template_path, "setup.py-tpl")
     if os.path.exists(setup_file):
         try:
@@ -151,6 +165,28 @@ def _parse_setup_dependencies(content: str) -> List[str]:
         return [dep for dep in deps if dep]  # Remove empty strings
 
     return []
+
+
+def _parse_pyproject_dependencies(pyproject_path: str) -> List[str]:
+    """
+    Parse dependencies from a ``pyproject.toml-tpl`` file.
+
+    Returns the list of PEP 508 requirement strings from
+    ``[project].dependencies``. Returns an empty list on parse errors so
+    callers can fall through to the next metadata source.
+    """
+    try:
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
+        debug_log(f"Error reading pyproject.toml template: {e}", "error")
+        return []
+
+    project = data.get("project", {})
+    raw_deps = project.get("dependencies", []) or []
+    if not isinstance(raw_deps, list):
+        return []
+    return [dep.strip() for dep in raw_deps if isinstance(dep, str) and dep.strip()]
 
 
 # ------------------------------------------------------------
@@ -332,6 +368,8 @@ def _process_pyproject_file(
         for placeholder, value in replacements.items():
             content = content.replace(placeholder, value)
 
+        content = _ensure_pyproject_fastkit_markers(content)
+
         with open(pyproject_toml, "w", encoding="utf-8") as f:
             f.write(content)
 
@@ -341,6 +379,41 @@ def _process_pyproject_file(
     except (OSError, UnicodeDecodeError) as e:
         debug_log(f"Error processing pyproject.toml: {e}", "error")
         raise BackendExceptions(f"Failed to process pyproject.toml: {e}")
+
+
+_DESCRIPTION_LINE_PATTERN = re.compile(
+    r'^(?P<prefix>description\s*=\s*)"(?P<value>.*?)"(?P<suffix>\s*)$',
+    re.MULTILINE,
+)
+
+
+def _ensure_pyproject_fastkit_markers(content: str) -> str:
+    """Idempotently ensure pyproject content carries FastAPI-fastkit markers.
+
+    Adds the canonical description marker if the ``description`` field does
+    not already include it (case-insensitive check), and appends a
+    ``[tool.fastapi-fastkit]`` section with ``managed = true`` if one is not
+    already present. Safe to run on already-marked content — no duplicates
+    are introduced.
+    """
+    marker = FASTKIT_DESCRIPTION_MARKER
+    match = _DESCRIPTION_LINE_PATTERN.search(content)
+    if match and marker.lower() not in match.group("value").lower():
+        existing = match.group("value")
+        new_value = f"{marker} {existing}".strip() if existing else marker
+        content = (
+            content[: match.start()]
+            + f'{match.group("prefix")}"{new_value}"{match.group("suffix")}'
+            + content[match.end() :]
+        )
+
+    tool_header = f"[tool.{FASTKIT_TOOL_SECTION}]"
+    if tool_header not in content:
+        if not content.endswith("\n"):
+            content += "\n"
+        content += f"\n{tool_header}\nmanaged = true\n"
+
+    return content
 
 
 def update_setup_py_dependencies(project_dir: str, dependencies: List[str]) -> None:
@@ -554,7 +627,7 @@ def _ensure_project_structure(src_dir: str) -> Dict[str, str]:
             # Create __init__.py if it doesn't exist
             init_file = os.path.join(dir_path, "__init__.py")
             if not os.path.exists(init_file):
-                with open(init_file, "w") as f:
+                with open(init_file, "w"):
                     pass
 
     return target_dirs

--- a/src/fastapi_fastkit/backend/package_managers/factory.py
+++ b/src/fastapi_fastkit/backend/package_managers/factory.py
@@ -136,7 +136,7 @@ class PackageManagerFactory:
         :param manager_class: Package manager class
         """
         if not issubclass(manager_class, BasePackageManager):
-            raise ValueError(f"Manager class must inherit from BasePackageManager")
+            raise ValueError("Manager class must inherit from BasePackageManager")
 
         self._managers[name.lower()] = manager_class
         debug_log(f"Registered package manager: {name}", "info")

--- a/src/fastapi_fastkit/backend/package_managers/pdm_manager.py
+++ b/src/fastapi_fastkit/backend/package_managers/pdm_manager.py
@@ -152,11 +152,11 @@ class PdmManager(BasePackageManager):
 
             # Create basic pyproject.toml content as string
             pyproject_content = f"""[project]
-name = "{project_name or 'fastapi-project'}"
+name = "{project_name or "fastapi-project"}"
 version = "0.1.0"
-description = "{description or 'A FastAPI project'}"
+description = "{description or "A FastAPI project"}"
 authors = [
-    {{name = "{author or 'Author'}", email = "{author_email or 'author@example.com'}"}},
+    {{name = "{author or "Author"}", email = "{author_email or "author@example.com"}"}},
 ]
 dependencies = {deps_toml}
 requires-python = ">=3.8"

--- a/src/fastapi_fastkit/backend/package_managers/poetry_manager.py
+++ b/src/fastapi_fastkit/backend/package_managers/poetry_manager.py
@@ -255,10 +255,10 @@ build-backend = "poetry.core.masonry.api"
 
             # Create basic pyproject.toml content for Poetry
             pyproject_content = f"""[tool.poetry]
-name = "{project_name or 'fastapi-project'}"
+name = "{project_name or "fastapi-project"}"
 version = "0.1.0"
-description = "{description or 'A FastAPI project'}"
-authors = ["{author or 'Author'} <{author_email or 'author@example.com'}>"]
+description = "{description or "A FastAPI project"}"
+authors = ["{author or "Author"} <{author_email or "author@example.com"}>"]
 readme = "README.md"
 license = "MIT"
 packages = [{{include = "src"}}]

--- a/src/fastapi_fastkit/backend/package_managers/uv_manager.py
+++ b/src/fastapi_fastkit/backend/package_managers/uv_manager.py
@@ -160,11 +160,11 @@ class UvManager(BasePackageManager):
 
             # Create basic pyproject.toml content for UV
             pyproject_content = f"""[project]
-name = "{project_name or 'fastapi-project'}"
+name = "{project_name or "fastapi-project"}"
 version = "0.1.0"
-description = "{description or 'A FastAPI project'}"
+description = "{description or "A FastAPI project"}"
 authors = [
-    {{name = "{author or 'Author'}", email = "{author_email or 'author@example.com'}"}},
+    {{name = "{author or "Author"}", email = "{author_email or "author@example.com"}"}},
 ]
 dependencies = {deps_toml}
 requires-python = ">=3.8"

--- a/src/fastapi_fastkit/backend/project_builder/config_generator.py
+++ b/src/fastapi_fastkit/backend/project_builder/config_generator.py
@@ -10,7 +10,6 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -179,11 +178,11 @@ class DynamicConfigGenerator:
         # App initialization
         project_name = self.config.get("project_name", "FastAPI App")
         description = self.config.get("description", "")
-        content_parts.append(f"app = FastAPI(")
+        content_parts.append("app = FastAPI(")
         content_parts.append(f'    title="{project_name}",')
         content_parts.append(f'    description="{description}",')
-        content_parts.append(f'    version="0.1.0",')
-        content_parts.append(f")")
+        content_parts.append('    version="0.1.0",')
+        content_parts.append(")")
         content_parts.append("")
 
         # App configuration

--- a/src/fastapi_fastkit/backend/transducer.py
+++ b/src/fastapi_fastkit/backend/transducer.py
@@ -10,7 +10,6 @@ import os
 import shutil
 from typing import Dict, Optional
 
-from fastapi_fastkit.core.settings import settings
 from fastapi_fastkit.utils.logging import debug_log, get_logger
 
 logger = get_logger(__name__)

--- a/src/fastapi_fastkit/cli.py
+++ b/src/fastapi_fastkit/cli.py
@@ -267,7 +267,7 @@ def startdemo(
     if template_deps:
         deps_table = create_info_table(
             "Template Dependencies",
-            {f"Dependency {i+1}": dep for i, dep in enumerate(template_deps)},
+            {f"Dependency {i + 1}": dep for i, dep in enumerate(template_deps)},
         )
         console.print("\n")
         console.print(deps_table)
@@ -579,7 +579,7 @@ def init(
     for stack_name, deps in settings.PROJECT_STACKS.items():
         table = create_info_table(
             f"{stack_name.upper()} Stack",
-            {f"Dependency {i+1}": dep for i, dep in enumerate(deps)},
+            {f"Dependency {i + 1}": dep for i, dep in enumerate(deps)},
         )
         console.print(table)
         console.print("\n")

--- a/src/fastapi_fastkit/fastapi_project_template/README.md
+++ b/src/fastapi_fastkit/fastapi_project_template/README.md
@@ -18,37 +18,72 @@ template-name/
 │ ├── models/
 │ ├── routes/
 │ └── utils/
-├── tests/
+├── tests/                    # required
 ├── scripts/
-├── requirements.txt-tpl
-├── setup.py-tpl
-└── README.md-tpl
+├── pyproject.toml-tpl        # preferred primary metadata file (PEP 621)
+├── setup.py-tpl              # legacy alternative, still accepted
+├── requirements.txt-tpl      # optional when pyproject.toml-tpl declares deps
+└── README.md-tpl             # required
 ```
+
+The minimum required files for a modern template are `tests/`, `README.md-tpl`,
+and at least one metadata file (`pyproject.toml-tpl` or `setup.py-tpl`).
+`requirements.txt-tpl` is optional when the template's dependencies are
+declared under `[project].dependencies` in `pyproject.toml-tpl`.
+
+Modern templates **SHOULD** ship `pyproject.toml-tpl` as the primary metadata
+file. `setup.py-tpl` remains supported for backward compatibility.
 
 ### Key Requirements:
 
 1. All source files must use `.py-tpl` extension
-2. `setup.py` must include `fastapi-fastkit` string in project description
-   for example:
+2. The template must declare `fastapi` as a dependency in at least one of:
+   - `pyproject.toml-tpl` under `[project].dependencies` (preferred)
+   - `requirements.txt-tpl`
+   - `setup.py-tpl` under `install_requires`
+3. `pyproject.toml-tpl` (preferred) should use PEP 621 metadata and carry the
+   FastAPI-fastkit identity markers so that `is_fastkit_project()` can tell
+   generated projects apart from unrelated FastAPI projects in the user's
+   workspace:
    ```
-   ...
-   setup(
-      ...
-      description = "[fastapi-fastkit templated] <description>",
-      ...
-   )
+   [project]
+   name = "<project_name>"
+   version = "0.1.0"
+   description = "[FastAPI-fastkit templated] <description>"
+   dependencies = [
+       "fastapi>=0.115.0",
+       ...
+   ]
+
+   [tool.fastapi-fastkit]
+   managed = true
    ```
-3. `setup.py` must include `install_requires` section, it must include essential dependencies for the template project. Also, note that install_requires list must be type annotated.
-   for example:
-   ```
-   ...
-   install_requires: list[str] = [
-      ...
-   ],
-   ```
-4. Basic CRUD operations example
-5. Unit tests implementation
-6. API documentation (OpenAPI/Swagger)
+   The `[FastAPI-fastkit templated]` marker in `description` and the
+   `[tool.fastapi-fastkit]` table are both recognized by detection (any one
+   suffices; matching is case-insensitive). Metadata injection will also add
+   these markers at project-generation time if a template forgets them, but
+   authors should include them explicitly.
+4. Legacy templates using `setup.py-tpl` should:
+   - declare dependencies via a type-annotated `install_requires` list, e.g.
+     ```
+     install_requires: list[str] = [
+        ...
+     ]
+     ```
+   - include the `[FastAPI-fastkit templated]` marker in the project
+     description. Detection falls back to a case-insensitive scan for
+     `fastapi-fastkit` in `setup.py`, so this marker keeps legacy projects
+     identifiable:
+     ```
+     setup(
+        ...
+        description = "[FastAPI-fastkit templated] <description>",
+        ...
+     )
+     ```
+5. Basic CRUD operations example
+6. Unit tests implementation
+7. API documentation (OpenAPI/Swagger)
 
 ## Base structure of modules template
 

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-async-crud/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-async-crud/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -40,6 +40,9 @@ dev = [
     "mypy>=1.15.0",
     "PyYAML>=6.0.2",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-custom-response/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-custom-response/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -40,6 +40,9 @@ dev = [
     "mypy>=1.15.0",
     "PyYAML>=6.0.2",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-default/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-default/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -37,6 +37,9 @@ dev = [
     "mypy>=1.15.0",
     "PyYAML>=6.0.2",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-dockerized/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-dockerized/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -40,6 +40,9 @@ dev = [
     "PyYAML>=6.0.2",
     "setuptools-scm>=8.1.0",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-empty/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-empty/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -33,6 +33,9 @@ dev = [
     "isort>=6.0.0",
     "mypy>=1.15.0",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-mcp/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-mcp/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -44,6 +44,9 @@ dev = [
     "mypy>=1.15.0",
     "PyYAML>=6.0.2",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-psql-orm/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-psql-orm/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -41,6 +41,9 @@ dev = [
     "mypy>=1.15.0",
     "PyYAML>=6.0.2",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/fastapi_project_template/fastapi-single-module/pyproject.toml-tpl
+++ b/src/fastapi_fastkit/fastapi_project_template/fastapi-single-module/pyproject.toml-tpl
@@ -1,7 +1,7 @@
 [project]
 name = "<project_name>"
 version = "0.1.0"
-description = "<description>"
+description = "[FastAPI-fastkit templated] <description>"
 authors = [
     {name = "<author>", email = "<author_email>"},
 ]
@@ -19,6 +19,9 @@ dev = [
     "pytest>=8.3.4",
     "httpx>=0.28.1",
 ]
+
+[tool.fastapi-fastkit]
+managed = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fastapi_fastkit/utils/main.py
+++ b/src/fastapi_fastkit/utils/main.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 import os
 import re
+import tomllib
 import traceback
 from typing import Any, Dict, Optional
 
@@ -22,6 +23,14 @@ logger = get_logger(__name__)
 
 # Email validation regex pattern
 REGEX = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b"
+
+
+# Canonical identity markers used to distinguish FastAPI-fastkit-managed
+# projects from unrelated FastAPI projects in the user workspace. Kept as
+# module-level constants so templates, metadata injection, and detection
+# logic all reference the same strings.
+FASTKIT_DESCRIPTION_MARKER = "[FastAPI-fastkit templated]"
+FASTKIT_TOOL_SECTION = "fastapi-fastkit"  # the [tool.<this>] table key
 
 
 def get_optimal_console_size() -> tuple[int, int]:
@@ -273,19 +282,77 @@ def validate_email(ctx: Context, param: Any, value: Any) -> Any:
 
 def is_fastkit_project(project_dir: str) -> bool:
     """
-    Check if the project was created with fastkit.
-    Inspects the contents of the setup.py file for FastAPI-fastkit markers.
+    Check if the project was created/managed by FastAPI-fastkit.
+
+    Detection precedence (any single match is sufficient):
+
+    1. ``pyproject.toml`` with ``[tool.fastapi-fastkit].managed = true``
+       (machine-readable marker; set by ``fastkit`` during project generation).
+    2. ``pyproject.toml`` ``[project].description`` contains the
+       ``[FastAPI-fastkit templated]`` marker (case-insensitive).
+    3. ``setup.py`` contains ``fastapi-fastkit`` (case-insensitive) — preserves
+       the legacy detection path for projects generated before the pyproject
+       marker existed.
 
     :param project_dir: Path to the project directory
     :return: True if the project was created with fastkit, False otherwise
     """
+    if _pyproject_marks_fastkit(os.path.join(project_dir, "pyproject.toml")):
+        return True
+
     setup_py = os.path.join(project_dir, "setup.py")
-    if not os.path.exists(setup_py):
+    if os.path.exists(setup_py):
+        try:
+            with open(setup_py, "r", encoding="utf-8") as f:
+                content = f.read()
+            if FASTKIT_TOOL_SECTION in content.lower():
+                return True
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    return False
+
+
+def _pyproject_marks_fastkit(pyproject_path: str) -> bool:
+    """Return True if ``pyproject.toml`` carries a FastAPI-fastkit marker.
+
+    Tries structured TOML parsing first (authoritative), falling back to a
+    plain-text scan if the file is malformed so detection still works on
+    hand-edited or partially written pyproject files.
+    """
+    if not os.path.exists(pyproject_path):
         return False
 
     try:
-        with open(setup_py, "r", encoding="utf-8") as f:
-            content = f.read()
-            return "FastAPI-fastkit" in content
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return _pyproject_text_marks_fastkit(pyproject_path)
+
+    tool_section = data.get("tool", {}).get(FASTKIT_TOOL_SECTION, {})
+    if isinstance(tool_section, dict) and tool_section.get("managed") is True:
+        return True
+
+    description = data.get("project", {}).get("description", "")
+    if (
+        isinstance(description, str)
+        and FASTKIT_DESCRIPTION_MARKER.lower() in description.lower()
+    ):
+        return True
+
+    return False
+
+
+def _pyproject_text_marks_fastkit(pyproject_path: str) -> bool:
+    """Fallback plain-text scan for malformed pyproject files."""
+    try:
+        with open(pyproject_path, "r", encoding="utf-8") as f:
+            content = f.read().lower()
     except (OSError, UnicodeDecodeError):
         return False
+
+    if f"[tool.{FASTKIT_TOOL_SECTION}]" in content:
+        return True
+    if FASTKIT_DESCRIPTION_MARKER.lower() in content:
+        return True
+    return False

--- a/tests/test_backends/test_inspector.py
+++ b/tests/test_backends/test_inspector.py
@@ -183,6 +183,146 @@ def test_example():
             "FastAPI dependency not found" in error for error in inspector.errors
         )
 
+    def _make_pyproject_template(self, dependencies: list[str]) -> None:
+        """Scaffold a pyproject-only template with the given ``[project].dependencies``."""
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "src").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Pyproject-only Template")
+        deps_block = ",\n    ".join(f'"{d}"' for d in dependencies)
+        (self.template_path / "pyproject.toml-tpl").write_text(
+            "[project]\n"
+            'name = "<project_name>"\n'
+            'version = "0.1.0"\n'
+            'description = "[fastapi-fastkit templated] pyproject-only"\n'
+            "dependencies = [\n"
+            f"    {deps_block}\n"
+            "]\n"
+        )
+        (self.template_path / "src" / "main.py-tpl").write_text(
+            "from fastapi import FastAPI\napp = FastAPI()\n"
+        )
+        (self.template_path / "tests" / "test_example.py-tpl").write_text(
+            "def test_example():\n    assert True\n"
+        )
+
+    def test_check_file_structure_pyproject_only(self, temp_dir: str) -> None:
+        """A template with only pyproject.toml-tpl (no setup.py-tpl) passes structure."""
+        # given
+        self._make_pyproject_template(["fastapi>=0.115.0"])
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_file_structure()
+
+        # then
+        assert result is True
+        assert inspector.errors == []
+
+    def test_check_file_structure_missing_metadata(self, temp_dir: str) -> None:
+        """Structure check fails when neither pyproject.toml-tpl nor setup.py-tpl exists."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_file_structure()
+
+        # then
+        assert result is False
+        assert any(
+            "pyproject.toml-tpl" in error and "setup.py-tpl" in error
+            for error in inspector.errors
+        )
+
+    def test_check_dependencies_pyproject_with_fastapi(self, temp_dir: str) -> None:
+        """Pyproject-only template with fastapi in [project].dependencies passes."""
+        # given
+        self._make_pyproject_template(["fastapi>=0.115.8", "uvicorn[standard]>=0.34.0"])
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_dependencies()
+
+        # then
+        assert result is True
+        assert inspector.errors == []
+
+    def test_check_dependencies_pyproject_without_fastapi(self, temp_dir: str) -> None:
+        """Pyproject-only template missing fastapi fails with a clear error."""
+        # given
+        # fastapi-users must not be confused with fastapi during name normalization.
+        self._make_pyproject_template(["fastapi-users>=13.0", "uvicorn>=0.34.0"])
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_dependencies()
+
+        # then
+        assert result is False
+        assert any(
+            "FastAPI dependency not found" in error and "pyproject.toml-tpl" in error
+            for error in inspector.errors
+        )
+
+    def test_check_dependencies_any_source_satisfies(self, temp_dir: str) -> None:
+        """A stale requirements.txt-tpl does not fail when pyproject declares fastapi.
+
+        The contract is "fastapi declared in at least one source". A template
+        whose requirements.txt-tpl has drifted (missing fastapi) but whose
+        pyproject.toml-tpl is authoritative must still pass.
+        """
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+        # requirements.txt-tpl WITHOUT fastapi (stale)
+        (self.template_path / "requirements.txt-tpl").write_text("uvicorn==0.24.0\n")
+        # pyproject.toml-tpl WITH fastapi (authoritative)
+        (self.template_path / "pyproject.toml-tpl").write_text(
+            "[project]\n"
+            'name = "<project_name>"\n'
+            'version = "0.1.0"\n'
+            "dependencies = [\n"
+            '    "fastapi>=0.115.0",\n'
+            "]\n"
+        )
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_dependencies()
+
+        # then
+        assert result is True
+        assert inspector.errors == []
+
+    def test_check_dependencies_setup_py_only_with_fastapi(self, temp_dir: str) -> None:
+        """Legacy setup.py-tpl-only template with fastapi in install_requires passes."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Legacy Template")
+        (self.template_path / "setup.py-tpl").write_text(
+            "from setuptools import setup\n"
+            "install_requires: list[str] = [\n"
+            '    "fastapi>=0.104.0",\n'
+            '    "uvicorn>=0.24.0",\n'
+            "]\n"
+            'setup(name="legacy", install_requires=install_requires)\n'
+        )
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_dependencies()
+
+        # then
+        assert result is True
+        assert inspector.errors == []
+
     @patch("fastapi_fastkit.backend.inspector.find_template_core_modules")
     def test_check_fastapi_implementation_valid(
         self, mock_find_modules: MagicMock, temp_dir: str
@@ -295,7 +435,7 @@ def test_example():
         with patch("os.makedirs", side_effect=OSError("Permission denied")):
             # when & then
             with pytest.raises(OSError, match="Permission denied"):
-                with TemplateInspector(str(self.template_path), temp_dir) as inspector:
+                with TemplateInspector(str(self.template_path), temp_dir):
                     pass  # Exception should be raised during __enter__
 
     def test_cleanup_method(self, temp_dir: str) -> None:
@@ -423,7 +563,6 @@ def test_example():
             patch.object(inspector, "_check_fastapi_implementation", return_value=True),
             patch.object(inspector, "_test_template", return_value=True),
         ):
-
             # when
             result = inspector.inspect_template()
 
@@ -446,17 +585,21 @@ def test_example():
             patch.object(inspector, "_check_fastapi_implementation", return_value=True),
             patch.object(inspector, "_test_template", return_value=True),
         ):
-
             # when
             result = inspector.inspect_template()
 
             # then
             assert result is False
 
-    def test_check_dependencies_missing_requirements_file(self, temp_dir: str) -> None:
-        """Test _check_dependencies when requirements.txt-tpl is missing."""
+    def test_check_dependencies_missing_requirements_file_falls_back_to_setup(
+        self, temp_dir: str
+    ) -> None:
+        """Without requirements.txt-tpl, the setup.py-tpl install_requires is consulted.
+
+        The setup.py-tpl here declares no fastapi dependency, so the check should
+        fail with an error referencing setup.py-tpl.
+        """
         # given
-        # Create structure without requirements.txt-tpl
         (self.template_path / "tests").mkdir(exist_ok=True)
         (self.template_path / "setup.py-tpl").write_text("from setuptools import setup")
         (self.template_path / "README.md-tpl").write_text("# Test")
@@ -469,13 +612,19 @@ def test_example():
         # then
         assert result is False
         assert any(
-            "requirements.txt-tpl not found" in error for error in inspector.errors
+            "FastAPI dependency not found" in error and "setup.py-tpl" in error
+            for error in inspector.errors
         )
 
-    def test_check_dependencies_missing_setup_file(self, temp_dir: str) -> None:
-        """Test _check_dependencies when setup.py-tpl is missing."""
+    def test_check_dependencies_requirements_without_setup_passes(
+        self, temp_dir: str
+    ) -> None:
+        """A template with requirements.txt-tpl (declaring fastapi) but no setup.py-tpl passes.
+
+        Under the pyproject-first contract, setup.py-tpl is not required as long
+        as fastapi is declared in requirements.txt-tpl.
+        """
         # given
-        # Create structure without setup.py-tpl
         (self.template_path / "tests").mkdir(exist_ok=True)
         (self.template_path / "requirements.txt-tpl").write_text("fastapi==0.104.1")
         (self.template_path / "README.md-tpl").write_text("# Test")
@@ -486,8 +635,8 @@ def test_example():
             result = inspector._check_dependencies()
 
         # then
-        assert result is False
-        assert any("setup.py-tpl not found" in error for error in inspector.errors)
+        assert result is True
+        assert inspector.errors == []
 
     def test_check_dependencies_file_read_error(self, temp_dir: str) -> None:
         """Test _check_dependencies with file read error."""
@@ -547,7 +696,6 @@ fallback_testing:
             "fastapi_fastkit.backend.transducer.copy_and_convert_template"
         ) as mock_copy:
             # Mock that config file exists in temp dir
-            temp_config_path = os.path.join("temp_dir", "template-config.yml")
             mock_copy.return_value = None
 
             inspector = TemplateInspector(str(self.template_path), temp_dir)
@@ -971,7 +1119,6 @@ fallback_testing:
                 inspector, "_test_with_fallback_strategy", return_value=True
             ) as mock_fallback,
         ):
-
             # when
             result = inspector._test_with_docker_strategy()
 
@@ -1008,7 +1155,6 @@ fallback_testing:
             ) as mock_install,
             patch.object(inspector, "_run_test_script_with_env") as mock_run_script,
         ):
-
             mock_create_venv.return_value = "/fake/venv"
             mock_install.return_value = True
             mock_run_script.return_value = MagicMock(

--- a/tests/test_backends/test_inspector.py
+++ b/tests/test_backends/test_inspector.py
@@ -323,6 +323,106 @@ def test_example():
         assert result is True
         assert inspector.errors == []
 
+    def test_check_dependencies_pyproject_parse_error(self, temp_dir: str) -> None:
+        """Malformed pyproject.toml-tpl surfaces a parse error and fails the check."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+        # Unterminated string makes tomllib raise TOMLDecodeError.
+        (self.template_path / "pyproject.toml-tpl").write_text(
+            '[project]\nname = "demo\nversion = "0.1.0"\n'
+        )
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_dependencies()
+
+        # then
+        assert result is False
+        assert any("Invalid pyproject.toml-tpl" in error for error in inspector.errors)
+
+    def test_check_dependencies_setup_py_read_error(self, temp_dir: str) -> None:
+        """OSError while reading setup.py-tpl surfaces a descriptive error."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+        (self.template_path / "setup.py-tpl").write_text(
+            'from setuptools import setup\nsetup(name="demo")\n'
+        )
+
+        # when — selectively fail the open() targeting setup.py-tpl only.
+        real_open = open
+
+        def selective_open(file, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if str(file).endswith("setup.py-tpl"):
+                raise OSError("Permission denied")
+            return real_open(file, *args, **kwargs)
+
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            with patch("builtins.open", side_effect=selective_open):
+                result = inspector._check_dependencies()
+
+        # then
+        assert result is False
+        assert any("Error reading setup.py-tpl" in error for error in inspector.errors)
+
+    def test_check_dependencies_no_sources_at_all(self, temp_dir: str) -> None:
+        """Calling _check_dependencies with no metadata files yields a clear error."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+
+        # when
+        with patch("fastapi_fastkit.backend.transducer.copy_and_convert_template"):
+            inspector = TemplateInspector(str(self.template_path), temp_dir)
+            result = inspector._check_dependencies()
+
+        # then
+        assert result is False
+        assert any("No dependency source found" in error for error in inspector.errors)
+
+    def test_extract_pyproject_dependency_names_non_list(self, temp_dir: str) -> None:
+        """Non-list [project].dependencies yields a descriptive parse error."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+        pyproject = self.template_path / "pyproject.toml-tpl"
+        pyproject.write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'dependencies = "fastapi>=0.115"\n'
+        )
+
+        # when
+        names, error = TemplateInspector._extract_pyproject_dependency_names(pyproject)
+
+        # then
+        assert names == set()
+        assert error is not None
+        assert "must be a list" in error
+
+    def test_extract_pyproject_dependency_names_skips_non_strings(
+        self, temp_dir: str
+    ) -> None:
+        """Non-string / empty entries in [project].dependencies are ignored."""
+        # given
+        (self.template_path / "tests").mkdir(exist_ok=True)
+        (self.template_path / "README.md-tpl").write_text("# Test")
+        pyproject = self.template_path / "pyproject.toml-tpl"
+        pyproject.write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            # Empty string and an integer-ish value are dropped without raising.
+            'dependencies = ["fastapi>=0.115", "", "   "]\n'
+        )
+
+        # when
+        names, error = TemplateInspector._extract_pyproject_dependency_names(pyproject)
+
+        # then
+        assert error is None
+        assert names == {"fastapi"}
+
     @patch("fastapi_fastkit.backend.inspector.find_template_core_modules")
     def test_check_fastapi_implementation_valid(
         self, mock_find_modules: MagicMock, temp_dir: str

--- a/tests/test_backends/test_interactive_config_builder.py
+++ b/tests/test_backends/test_interactive_config_builder.py
@@ -3,9 +3,7 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import patch
 
 from fastapi_fastkit.backend.interactive.config_builder import InteractiveConfigBuilder
 from fastapi_fastkit.core.settings import FastkitConfig

--- a/tests/test_backends/test_interactive_prompts.py
+++ b/tests/test_backends/test_interactive_prompts.py
@@ -3,9 +3,7 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from fastapi_fastkit.backend.interactive import prompts
 from fastapi_fastkit.core.settings import FastkitConfig

--- a/tests/test_backends/test_interactive_selectors.py
+++ b/tests/test_backends/test_interactive_selectors.py
@@ -3,9 +3,7 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from fastapi_fastkit.backend.interactive.selectors import (
     confirm_selections,

--- a/tests/test_backends/test_interactive_validators.py
+++ b/tests/test_backends/test_interactive_validators.py
@@ -3,7 +3,6 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-import pytest
 
 from fastapi_fastkit.backend.interactive.validators import (
     sanitize_custom_packages,

--- a/tests/test_backends/test_main.py
+++ b/tests/test_backends/test_main.py
@@ -12,9 +12,12 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from fastapi_fastkit.backend.main import (
+    _ensure_pyproject_fastkit_markers,
+    _parse_pyproject_dependencies,
     _parse_setup_dependencies,
     _process_config_file,
     _process_main_file,
+    _process_pyproject_file,
     _process_setup_file,
     add_new_route,
     create_venv,
@@ -348,6 +351,156 @@ setup(
             assert "fastapi>=0.100.0" in result
             assert "uvicorn[standard]>=0.23.0" in result
             assert "pydantic>=2.0.0" in result
+
+        finally:
+            import shutil
+
+            shutil.rmtree(str(template_path))
+
+    def test_read_template_stack_pyproject_only(self) -> None:
+        """read_template_stack reads [project].dependencies from pyproject-only templates."""
+        # given
+        template_path = Path(tempfile.mkdtemp())
+        try:
+            (template_path / "pyproject.toml-tpl").write_text(
+                "[project]\n"
+                'name = "<project_name>"\n'
+                'version = "0.1.0"\n'
+                "dependencies = [\n"
+                '    "fastapi>=0.115.8",\n'
+                '    "uvicorn[standard]>=0.34.0",\n'
+                "]\n"
+            )
+
+            # when
+            result = read_template_stack(str(template_path))
+
+            # then
+            assert "fastapi>=0.115.8" in result
+            assert "uvicorn[standard]>=0.34.0" in result
+
+        finally:
+            import shutil
+
+            shutil.rmtree(str(template_path))
+
+    def test_read_template_stack_precedence_requirements_over_pyproject(self) -> None:
+        """requirements.txt-tpl wins over pyproject.toml-tpl to preserve legacy behaviour."""
+        # given
+        template_path = Path(tempfile.mkdtemp())
+        try:
+            (template_path / "requirements.txt-tpl").write_text(
+                "fastapi>=0.100.0\nuvicorn>=0.23.0\n"
+            )
+            (template_path / "pyproject.toml-tpl").write_text(
+                "[project]\n"
+                'name = "test"\n'
+                'version = "0.1.0"\n'
+                "dependencies = [\n"
+                '    "fastapi>=0.999.0",\n'  # distinct marker — must NOT be chosen
+                "]\n"
+            )
+
+            # when
+            result = read_template_stack(str(template_path))
+
+            # then
+            assert "fastapi>=0.100.0" in result
+            assert "uvicorn>=0.23.0" in result
+            assert "fastapi>=0.999.0" not in result
+
+        finally:
+            import shutil
+
+            shutil.rmtree(str(template_path))
+
+    def test_parse_pyproject_dependencies_malformed(self) -> None:
+        """_parse_pyproject_dependencies returns [] on TOML parse errors."""
+        # given
+        template_path = Path(tempfile.mkdtemp())
+        try:
+            pyproject = template_path / "pyproject.toml-tpl"
+            pyproject.write_text("[project\nname = broken")
+
+            # when
+            result = _parse_pyproject_dependencies(str(pyproject))
+
+            # then
+            assert result == []
+
+        finally:
+            import shutil
+
+            shutil.rmtree(str(template_path))
+
+    def test_ensure_pyproject_fastkit_markers_adds_both(self) -> None:
+        """Injects the description marker and tool section when neither is present."""
+        content = (
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'description = "an app"\n\n[build-system]\nrequires = ["hatchling"]\n'
+        )
+        result = _ensure_pyproject_fastkit_markers(content)
+
+        assert 'description = "[FastAPI-fastkit templated] an app"' in result
+        assert "[tool.fastapi-fastkit]" in result
+        assert "managed = true" in result
+
+    def test_ensure_pyproject_fastkit_markers_is_idempotent(self) -> None:
+        """Running injection twice must not duplicate markers."""
+        content = (
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'description = "[FastAPI-fastkit templated] an app"\n\n'
+            "[tool.fastapi-fastkit]\nmanaged = true\n"
+        )
+        once = _ensure_pyproject_fastkit_markers(content)
+        twice = _ensure_pyproject_fastkit_markers(once)
+
+        assert once == twice
+        assert once.count("[FastAPI-fastkit templated]") == 1
+        assert once.count("[tool.fastapi-fastkit]") == 1
+
+    def test_ensure_pyproject_fastkit_markers_preserves_existing_marker_case_insensitive(
+        self,
+    ) -> None:
+        """A description already carrying a lowercase marker is not re-prepended."""
+        content = (
+            '[project]\nname = "demo"\n'
+            'description = "[fastapi-fastkit templated] legacy text"\n'
+        )
+        result = _ensure_pyproject_fastkit_markers(content)
+
+        # Lowercase is preserved, marker is not duplicated.
+        assert result.count("fastapi-fastkit templated") == 1
+        assert "[fastapi-fastkit templated] legacy text" in result
+
+    def test_process_pyproject_file_writes_markers_into_generated_pyproject(
+        self,
+    ) -> None:
+        """End-to-end: _process_pyproject_file replaces placeholders and injects markers."""
+        template_path = Path(tempfile.mkdtemp())
+        try:
+            pyproject = template_path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "<project_name>"\nversion = "0.1.0"\n'
+                'description = "<description>"\n'
+                'authors = [{name = "<author>", email = "<author_email>"}]\n'
+                'dependencies = ["fastapi>=0.115"]\n\n'
+                '[build-system]\nrequires = ["hatchling"]\n'
+            )
+
+            _process_pyproject_file(
+                str(pyproject),
+                project_name="demo",
+                author="Me",
+                author_email="me@example.com",
+                description="an app",
+            )
+
+            final = pyproject.read_text()
+            assert 'name = "demo"' in final
+            assert 'description = "[FastAPI-fastkit templated] an app"' in final
+            assert "[tool.fastapi-fastkit]" in final
+            assert "managed = true" in final
 
         finally:
             import shutil

--- a/tests/test_backends/test_main.py
+++ b/tests/test_backends/test_main.py
@@ -507,6 +507,42 @@ setup(
 
             shutil.rmtree(str(template_path))
 
+    def test_parse_pyproject_dependencies_non_list_value(self) -> None:
+        """Non-list dependencies value returns [] rather than raising."""
+        template_path = Path(tempfile.mkdtemp())
+        try:
+            pyproject = template_path / "pyproject.toml-tpl"
+            # A string in place of a dependencies array exercises the
+            # defensive isinstance() guard.
+            pyproject.write_text(
+                '[project]\nname = "demo"\nversion = "0.1.0"\n'
+                'dependencies = "fastapi>=0.115"\n'
+            )
+
+            result = _parse_pyproject_dependencies(str(pyproject))
+
+            assert result == []
+
+        finally:
+            import shutil
+
+            shutil.rmtree(str(template_path))
+
+    def test_ensure_pyproject_fastkit_markers_appends_newline_when_missing(
+        self,
+    ) -> None:
+        """Content without a trailing newline gets one before the tool section."""
+        content = '[project]\nname = "demo"\ndescription = "x"'
+        assert not content.endswith("\n")
+
+        result = _ensure_pyproject_fastkit_markers(content)
+
+        # Marker + tool section are present and the output ends cleanly.
+        assert "[tool.fastapi-fastkit]" in result
+        assert result.endswith("managed = true\n")
+        # No doubled newlines immediately before the inserted table.
+        assert "\n\n\n[tool.fastapi-fastkit]" not in result
+
     @patch("builtins.open", mock_open(read_data="fastapi>=0.100.0"))
     @patch("os.path.exists", return_value=True)
     def test_read_template_stack_file_read_error(self, mock_exists: MagicMock) -> None:

--- a/tests/test_backends/test_project_builder_config_generator.py
+++ b/tests/test_backends/test_project_builder_config_generator.py
@@ -7,8 +7,6 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from fastapi_fastkit.backend.project_builder.config_generator import (
     DynamicConfigGenerator,
 )

--- a/tests/test_backends/test_project_builder_dependency_collector.py
+++ b/tests/test_backends/test_project_builder_dependency_collector.py
@@ -3,7 +3,6 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-import pytest
 
 from fastapi_fastkit.backend.project_builder.dependency_collector import (
     DependencyCollector,

--- a/tests/test_cli_operations/test_cli.py
+++ b/tests/test_cli_operations/test_cli.py
@@ -222,7 +222,7 @@ class TestCLI:
         # given
         os.chdir(temp_dir)
         project_name = "test-project"
-        result = self.runner.invoke(
+        self.runner.invoke(
             fastkit_cli,
             ["startdemo", "fastapi-default"],
             input="\n".join(
@@ -241,7 +241,7 @@ class TestCLI:
         assert project_path.exists() and project_path.is_dir()
 
         # when
-        result = self.runner.invoke(
+        self.runner.invoke(
             fastkit_cli,
             ["deleteproject", project_name],
             input="N",
@@ -459,7 +459,7 @@ class TestCLI:
         project_name = "test-cancel"
 
         # when
-        result = self.runner.invoke(
+        self.runner.invoke(
             fastkit_cli,
             ["init"],
             input="\n".join(

--- a/tests/test_cli_operations/test_cli_interactive_integration.py
+++ b/tests/test_cli_operations/test_cli_interactive_integration.py
@@ -182,10 +182,10 @@ class TestCLIInteractiveMode:
             "pytest" in deps_lower or "httpx" in deps_lower
         ), "Testing dependencies should be present"
 
-        print(f"\n✅ Interactive mode created full-stack project successfully!")
+        print("\n✅ Interactive mode created full-stack project successfully!")
         print(f"Project: {project_name}")
-        print(f"Stack: PostgreSQL + JWT + Celery + Redis + Prometheus")
-        print(f"Dependencies validated in pyproject.toml")
+        print("Stack: PostgreSQL + JWT + Celery + Redis + Prometheus")
+        print("Dependencies validated in pyproject.toml")
 
         # Check venv was created
         venv_path = project_path / ".venv"

--- a/tests/test_rich/test_rich.py
+++ b/tests/test_rich/test_rich.py
@@ -8,10 +8,7 @@ import os
 import sys
 from io import StringIO
 from typing import Any
-from unittest.mock import MagicMock, patch
-
-import pytest
-from rich.console import Console
+from unittest.mock import MagicMock
 
 from fastapi_fastkit.utils.logging import (
     DebugFileHandler,
@@ -292,10 +289,10 @@ class TestLoggingFunctions:
     def test_clear_logger_cache_function(self) -> None:
         """Test clear_logger_cache function."""
         # given
-        logger1 = get_logger("cache-test-logger")
+        get_logger("cache-test-logger")
 
         # Verify cache info before clearing
-        cache_info_before = get_logger.cache_info()
+        get_logger.cache_info()
 
         # when
         clear_logger_cache()

--- a/tests/test_templates/test_all_templates.py
+++ b/tests/test_templates/test_all_templates.py
@@ -222,6 +222,10 @@ class TestAllTemplates:
         readme_path = template_path / "README.md-tpl"
         assert readme_path.exists(), f"README.md-tpl not found in {template_name}"
 
-        # Should have setup.py-tpl
+        # Should have at least one metadata file (pyproject.toml-tpl preferred,
+        # setup.py-tpl accepted for backward compatibility).
+        pyproject_path = template_path / "pyproject.toml-tpl"
         setup_path = template_path / "setup.py-tpl"
-        assert setup_path.exists(), f"setup.py-tpl not found in {template_name}"
+        assert (
+            pyproject_path.exists() or setup_path.exists()
+        ), f"Neither pyproject.toml-tpl nor setup.py-tpl found in {template_name}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,6 +265,61 @@ setup(
 
         assert is_fastkit_project(str(project_path)) is True
 
+    def test_is_fastkit_project_malformed_pyproject_tool_section_text(
+        self, temp_dir: str
+    ) -> None:
+        """Malformed pyproject with a [tool.fastapi-fastkit] header is still detected."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "broken-with-tool"
+        project_path.mkdir()
+        # Unterminated string makes tomllib fail, but the text-fallback spots
+        # the [tool.fastapi-fastkit] header.
+        (project_path / "pyproject.toml").write_text(
+            '[project\nname = "broken\n\n[tool.fastapi-fastkit]\nmanaged = true\n'
+        )
+
+        assert is_fastkit_project(str(project_path)) is True
+
+    def test_is_fastkit_project_malformed_pyproject_no_markers(
+        self, temp_dir: str
+    ) -> None:
+        """Malformed pyproject with neither marker falls through to False."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "broken-unmarked"
+        project_path.mkdir()
+        (project_path / "pyproject.toml").write_text(
+            '[project\nname = "broken\ndescription = "nothing here"\n'
+        )
+
+        assert is_fastkit_project(str(project_path)) is False
+
+    def test_is_fastkit_project_setup_py_read_error(self, temp_dir: str) -> None:
+        """OSError while reading setup.py does not crash detection; returns False."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "setup-read-err"
+        project_path.mkdir()
+        (project_path / "setup.py").write_text(
+            'from setuptools import setup\nsetup(name="demo")\n'
+        )
+
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
+            assert is_fastkit_project(str(project_path)) is False
+
+    def test_pyproject_text_marks_fastkit_read_error(self, temp_dir: str) -> None:
+        """Text fallback swallows OSError and returns False cleanly."""
+        from fastapi_fastkit.utils.main import _pyproject_text_marks_fastkit
+
+        project_path = Path(temp_dir) / "text-fallback-err"
+        project_path.mkdir()
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text("whatever")
+
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
+            assert _pyproject_text_marks_fastkit(str(pyproject)) is False
+
     def test_print_error_with_traceback(self) -> None:
         """Test print_error function with traceback enabled."""
         # given

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,8 @@
 #
 # @author bnbong bbbong9@gmail.com
 # --------------------------------------------------------------------------
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from fastapi_fastkit.core.settings import FastkitConfig
 from fastapi_fastkit.utils.logging import setup_logging
@@ -177,6 +174,96 @@ setup(
 
         # when & then
         assert is_fastkit_project(nonexistent_path) is False
+
+    def test_is_fastkit_project_pyproject_tool_section(self, temp_dir: str) -> None:
+        """Pyproject with [tool.fastapi-fastkit].managed = true is detected."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "pyproject-tool-project"
+        project_path.mkdir()
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'description = "an unrelated description"\n\n'
+            "[tool.fastapi-fastkit]\nmanaged = true\n"
+        )
+
+        assert is_fastkit_project(str(project_path)) is True
+
+    def test_is_fastkit_project_pyproject_description_marker_only(
+        self, temp_dir: str
+    ) -> None:
+        """Pyproject with only the description marker (no tool section) is detected."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "pyproject-desc-project"
+        project_path.mkdir()
+        # Lowercase marker confirms case-insensitive matching.
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'description = "[fastapi-fastkit templated] demo"\n'
+        )
+
+        assert is_fastkit_project(str(project_path)) is True
+
+    def test_is_fastkit_project_legacy_setup_py_only(self, temp_dir: str) -> None:
+        """Project with only a legacy setup.py marker is still detected."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "legacy-setup-project"
+        project_path.mkdir()
+        # Mixed-case marker exercises case-insensitive setup.py scan.
+        (project_path / "setup.py").write_text(
+            "from setuptools import setup\n"
+            'setup(name="legacy", description="[FASTAPI-FASTKIT templated] legacy")\n'
+        )
+
+        assert is_fastkit_project(str(project_path)) is True
+
+    def test_is_fastkit_project_unrelated_fastapi_project(self, temp_dir: str) -> None:
+        """An unrelated FastAPI project with neither marker is NOT detected."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "unrelated-fastapi"
+        project_path.mkdir()
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "unrelated"\nversion = "0.1.0"\n'
+            'description = "A regular FastAPI app"\n'
+            'dependencies = ["fastapi>=0.115"]\n'
+        )
+
+        assert is_fastkit_project(str(project_path)) is False
+
+    def test_is_fastkit_project_pyproject_precedence_over_setup_py(
+        self, temp_dir: str
+    ) -> None:
+        """Pyproject marker alone is sufficient even without a setup.py."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "pyproject-only-detection"
+        project_path.mkdir()
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'description = "demo"\n\n'
+            "[tool.fastapi-fastkit]\nmanaged = true\n"
+        )
+
+        assert is_fastkit_project(str(project_path)) is True
+
+    def test_is_fastkit_project_malformed_pyproject_falls_back(
+        self, temp_dir: str
+    ) -> None:
+        """A malformed pyproject still detects the marker via plain-text scan."""
+        from fastapi_fastkit.utils.main import is_fastkit_project
+
+        project_path = Path(temp_dir) / "broken-pyproject"
+        project_path.mkdir()
+        # Invalid TOML (unterminated string) but the marker text is present.
+        (project_path / "pyproject.toml").write_text(
+            '[project\nname = "broken\n'
+            'description = "[FastAPI-fastkit templated] broken"\n'
+        )
+
+        assert is_fastkit_project(str(project_path)) is True
 
     def test_print_error_with_traceback(self) -> None:
         """Test print_error function with traceback enabled."""


### PR DESCRIPTION
# Requesting Merging

## Description

Part of #41  
Addresses #42

This PR completes the `pyproject-first` template contract work for v1.3.0 and adds the related project-identification safety updates needed for FastAPI-fastkit-managed projects.

The main goal of this change is to let new templates work with `pyproject.toml-tpl` as the primary metadata source without breaking existing templates, while still preserving FastAPI-fastkit's ability to distinguish its own generated projects from unrelated FastAPI backends in the user's workspace.

## Type of Change

- [ ] BUG FIX
- [ ] ADDING NEW TEMPLATE
- [x] FEATURE ADDED/UPDATED
- [ ] HOTFIX
- [ ] DELETING UNNECESSARY FEATURES
- [x] DOCUMENTATION & DEVOPS
- [ ] Etc..


## Test Environment

- Local macOS (Apple Silicon / M1), zsh
- Python via `uv`
- Verified test command:
  - `uv run pytest tests/test_backends/test_inspector.py tests/test_backends/test_main.py tests/test_templates/test_all_templates.py -q`
  - Result: `148 passed`

## Major Changes

- Modernized the template contract to support `pyproject.toml-tpl` as the primary metadata file
  - Templates now pass structural validation as long as they include:
    - `tests/`
    - `README.md-tpl`
    - at least one metadata file: `pyproject.toml-tpl` or `setup.py-tpl`
  - `requirements.txt-tpl` is no longer strictly required when dependencies are declared in `pyproject.toml-tpl`

- Updated dependency resolution logic for templates
  - `read_template_stack()` now supports:
    - `requirements.txt-tpl`
    - `pyproject.toml-tpl`
    - `setup.py-tpl`
  - Existing templates retain legacy precedence behavior

- Extended template inspection for pyproject-first templates
  - Inspector now accepts pyproject-only templates
  - Added focused validation for `pyproject.toml-tpl [project].dependencies`
  - Kept legacy `setup.py-tpl` support for backward compatibility

- Added FastAPI-fastkit identification metadata to pyproject-based templates
  - Standardized the description marker:
    - `[FastAPI-fastkit templated]`
  - Added a machine-readable section:
    - `[tool.fastapi-fastkit]`
    - `managed = true`

- Enhanced FastAPI-fastkit project detection logic
  - `is_fastkit_project()` now detects managed projects by checking:
    1. `pyproject.toml` `[tool.fastapi-fastkit].managed == true`
    2. fallback: pyproject description marker
    3. fallback: legacy `setup.py` marker
  - Matching is handled robustly for legacy/new structures

- Updated documentation to match the new contract
  - `src/fastapi_fastkit/fastapi_project_template/README.md`
  - `docs/en/contributing/template-creation-guide.md`
  - `docs/en/reference/template-quality-assurance.md`

- Added and updated tests for:
  - pyproject-only template validation
  - metadata-file requirement changes
  - dependency parsing from pyproject
  - detection of FastAPI-fastkit-managed projects via pyproject and legacy setup.py
  - preserved legacy precedence behavior

## Screenshots (optional)

N/A

## Etc

- This PR intentionally preserves backward compatibility for all currently shipped templates.
- The canonical marker string used in this PR is `[FastAPI-fastkit templated]`.
- The new pyproject marker support is intended to safely support upcoming pyproject-first templates such as `fastapi-domain-starter`.
