### PR TITLE
[FEATURE, DOCS] add architecture preset selection to interactive init

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -188,6 +188,15 @@ Enter the author name: John Doe
 Enter the author email: john@example.com
 Enter the project description: Full-stack FastAPI project with PostgreSQL and JWT
 
+🧱 Architecture Preset
+Pick a project layout. Press Enter to accept the recommended default.
+  1. minimal           - Smallest viable FastAPI app
+  2. single-module     - Everything in one module (prototypes / scripts)
+  3. classic-layered   - api/routes + crud + schemas + core (à la fastapi-default)
+  4. domain-starter    - Domain-oriented src/app/domains/<concept>/ (recommended)
+
+Select architecture preset: [4]
+
 🗄️ Database Selection
 Select database (PostgreSQL, MySQL, MongoDB, Redis, SQLite, None):
   1. PostgreSQL - PostgreSQL database with SQLAlchemy

--- a/docs/en/reference/faq.md
+++ b/docs/en/reference/faq.md
@@ -178,10 +178,23 @@ $ fastkit init --interactive
 
 </div>
 
-Interactive mode allows you to select from a comprehensive feature catalog:
+Interactive mode walks you through these steps in order:
+
+1. **Project information** — name, author, email, description.
+2. **Architecture preset** — picks the project layout. The recommended
+   default is `domain-starter`; press Enter to accept it.
+3. **Feature selections** — database, authentication, background tasks,
+   caching, monitoring, testing, utilities, deployment.
+4. **Package manager and custom packages** — pip / uv / pdm / poetry,
+   plus any extras you want pinned.
+5. **Confirmation** — a summary table shows every choice (including the
+   architecture preset) before the project is created.
+
+Interactive mode lets you select from a comprehensive feature catalog:
 
 | Category | Available Options |
 |----------|-------------------|
+| **Architecture** | minimal, single-module, classic-layered, **domain-starter** (recommended default) |
 | **Database** | PostgreSQL, MySQL, MongoDB, Redis, SQLite |
 | **Authentication** | JWT, OAuth2, FastAPI-Users, Session-based |
 | **Background Tasks** | Celery, Dramatiq |

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -188,6 +188,15 @@ Enter the author name: John Doe
 Enter the author email: john@example.com
 Enter the project description: Full-stack FastAPI project with PostgreSQL and JWT
 
+🧱 Architecture Preset
+프로젝트 레이아웃을 선택합니다. Enter를 누르면 추천 기본값이 적용됩니다.
+  1. minimal           - 가장 작은 FastAPI 앱
+  2. single-module     - 단일 모듈 구성 (프로토타입 / 스크립트용)
+  3. classic-layered   - api/routes + crud + schemas + core (fastapi-default 형태)
+  4. domain-starter    - 도메인 지향 src/app/domains/<concept>/ (recommended)
+
+Select architecture preset: [4]
+
 🗄️ Database Selection
 Select database (PostgreSQL, MySQL, MongoDB, Redis, SQLite, None):
   1. PostgreSQL - PostgreSQL database with SQLAlchemy
@@ -233,7 +242,7 @@ Select monitoring (Loguru, OpenTelemetry, Prometheus, None):
   4. None - No monitoring
 
 Select monitoring: 3
-```
+
 
 🧪 테스트 프레임워크 선택
 테스트 프레임워크를 선택하세요 (Basic, Coverage, Advanced, None):

--- a/src/fastapi_fastkit/backend/interactive/__init__.py
+++ b/src/fastapi_fastkit/backend/interactive/__init__.py
@@ -9,6 +9,7 @@
 from .config_builder import InteractiveConfigBuilder
 from .prompts import (
     prompt_additional_features,
+    prompt_architecture_preset,
     prompt_authentication_selection,
     prompt_basic_info,
     prompt_caching_selection,
@@ -31,6 +32,7 @@ from .validators import (
 __all__ = [
     "InteractiveConfigBuilder",
     "prompt_basic_info",
+    "prompt_architecture_preset",
     "prompt_template_selection",
     "prompt_database_selection",
     "prompt_authentication_selection",

--- a/src/fastapi_fastkit/backend/interactive/config_builder.py
+++ b/src/fastapi_fastkit/backend/interactive/config_builder.py
@@ -12,6 +12,7 @@ from fastapi_fastkit.utils.main import console, print_warning
 
 from .prompts import (
     prompt_additional_features,
+    prompt_architecture_preset,
     prompt_basic_info,
     prompt_template_selection,
 )
@@ -51,11 +52,15 @@ class InteractiveConfigBuilder:
         # Step 1: Basic information
         self._collect_basic_info()
 
-        # Step 2: Always use Empty template as base for interactive mode
+        # Step 2: Architecture preset — chosen early so downstream prompts
+        # (and later, preset-specific scaffolding) can branch on the layout.
+        self._collect_architecture_preset()
+
+        # Step 3: Always use Empty template as base for interactive mode
         # (Feature selection will build the project incrementally)
         self.config["base_template"] = None  # None = Empty project
 
-        # Step 3: Feature selections
+        # Step 4: Feature selections
         self._collect_feature_selections()
 
         # Step 4: Build final configuration
@@ -77,6 +82,20 @@ class InteractiveConfigBuilder:
         """Collect basic project information."""
         basic_info = prompt_basic_info()
         self.config.update(basic_info)
+
+    def _collect_architecture_preset(self) -> None:
+        """Collect the user's architecture preset choice.
+
+        Persists the canonical id on the config under ``architecture_preset``
+        (used by downstream code) plus the human-readable description under
+        ``architecture_preset_description`` (used by the confirmation summary
+        so users see what their choice means, not just the raw id).
+        """
+        preset = prompt_architecture_preset(self.settings)
+        self.config["architecture_preset"] = preset
+        self.config["architecture_preset_description"] = (
+            self.settings.ARCHITECTURE_PRESETS.get(preset, "")
+        )
 
     def _collect_template_selection(self) -> None:
         """Collect template selection."""

--- a/src/fastapi_fastkit/backend/interactive/prompts.py
+++ b/src/fastapi_fastkit/backend/interactive/prompts.py
@@ -63,6 +63,58 @@ def prompt_basic_info() -> Dict[str, str]:
     }
 
 
+def prompt_architecture_preset(settings: Any) -> str:
+    """
+    Prompt for the project's architecture preset.
+
+    Run early in the interactive flow so downstream prompts (and later,
+    preset-specific scaffolding) can branch on the user's choice. Returns
+    the canonical preset id (one of the keys in
+    ``settings.ARCHITECTURE_PRESETS``).
+
+    The recommended default (``settings.DEFAULT_ARCHITECTURE_PRESET``) is
+    annotated as such in the rendered table so users can spot it at a glance
+    and accept it with a single Enter press.
+
+    Args:
+        settings: FastkitConfig instance
+
+    Returns:
+        Preset id, e.g. ``"domain-starter"``.
+    """
+    console.print("\n[bold cyan]🧱 Architecture Preset[/bold cyan]")
+    console.print(
+        "[dim]Pick a project layout. Generation logic for each preset is "
+        "rolled out incrementally — your choice is recorded in the "
+        "config either way.[/dim]\n"
+    )
+
+    presets: Dict[str, str] = settings.ARCHITECTURE_PRESETS
+    default_id: str = settings.DEFAULT_ARCHITECTURE_PRESET
+    # Derive a display-only mapping so the recommended default is visibly
+    # annotated without mutating the canonical catalog in settings.
+    display_options: Dict[str, str] = {
+        preset_id: (
+            f"{description} [bold green](recommended default)[/bold green]"
+            if preset_id == default_id
+            else description
+        )
+        for preset_id, description in presets.items()
+    }
+    render_selection_table("Architecture Presets", display_options)
+
+    preset_ids = list(presets.keys())
+    default_idx = preset_ids.index(default_id) + 1
+
+    choice = click.prompt(
+        f"\nSelect architecture preset (default: {default_id})",
+        type=click.IntRange(1, len(preset_ids)),
+        default=default_idx,
+    )
+
+    return cast(str, preset_ids[choice - 1])
+
+
 def prompt_template_selection(settings: Any) -> Optional[str]:
     """
     Prompt for base template selection.

--- a/src/fastapi_fastkit/backend/interactive/selectors.py
+++ b/src/fastapi_fastkit/backend/interactive/selectors.py
@@ -133,6 +133,16 @@ def confirm_selections(config: Dict[str, Any]) -> bool:
     table.add_row("Email", config.get("author_email", "N/A"))
     table.add_row("Description", config.get("description", "N/A"))
 
+    # Architecture preset (interactive ``init`` always sets this; older
+    # callers may not — guard with a falsy check to stay backward compatible).
+    preset = config.get("architecture_preset")
+    if preset:
+        preset_description = config.get("architecture_preset_description", "")
+        table.add_row(
+            "Architecture Preset",
+            f"{preset} — {preset_description}" if preset_description else preset,
+        )
+
     # Template
     if config.get("base_template"):
         table.add_row("Base Template", config["base_template"])

--- a/src/fastapi_fastkit/cli.py
+++ b/src/fastapi_fastkit/cli.py
@@ -334,7 +334,11 @@ def startdemo(
     "--interactive",
     is_flag=True,
     default=False,
-    help="Enable interactive mode for guided project setup with feature selection.",
+    help=(
+        "Enable interactive mode for guided project setup. Walks through an "
+        "architecture preset (minimal / single-module / classic-layered / "
+        "domain-starter, default: domain-starter), then feature selection."
+    ),
 )
 @click.option(
     "--project-name",
@@ -372,7 +376,11 @@ def init(
     """
     Start a FastAPI project setup.
 
-    Use --interactive for guided setup with dynamic feature selection.
+    Use --interactive for guided setup. Interactive mode prompts for an
+    architecture preset (``minimal`` / ``single-module`` / ``classic-layered``
+    / ``domain-starter`` — default: ``domain-starter``) and then walks
+    through feature selection (database, auth, testing, deployment, ...).
+
     Without --interactive, creates an empty project with predefined stacks.
 
     This command will automatically create a new FastAPI project directory

--- a/src/fastapi_fastkit/core/settings.py
+++ b/src/fastapi_fastkit/core/settings.py
@@ -45,6 +45,20 @@ class FastkitConfig:
         },
     }
 
+    # Architecture Presets (interactive ``init`` wizard)
+    #
+    # The preset shapes how the generated project is laid out (single file vs.
+    # layered vs. domain-oriented). Preset-specific generation logic lives in
+    # later issues — this catalog is the user-facing menu and the canonical
+    # set of preset ids persisted in the interactive config.
+    ARCHITECTURE_PRESETS: dict[str, str] = {
+        "minimal": "Smallest viable FastAPI app — a single app + a couple of files.",
+        "single-module": "Everything in one module; ideal for tiny scripts and prototypes.",
+        "classic-layered": "Layered split: api/routes, crud, schemas, core (a la fastapi-default).",
+        "domain-starter": "Domain-oriented: src/app/domains/<concept>/ with router/service/repository (recommended).",
+    }
+    DEFAULT_ARCHITECTURE_PRESET: str = "domain-starter"
+
     # Startproject Options
     PROJECT_STACKS: dict[str, list[str]] = {
         "minimal": ["fastapi", "uvicorn", "pydantic", "pydantic-settings"],

--- a/tests/test_backends/test_interactive_config_builder.py
+++ b/tests/test_backends/test_interactive_config_builder.py
@@ -235,6 +235,33 @@ class TestBuildFinalConfig:
         assert final_config["author"] == "Test Author"
 
 
+class TestCollectArchitecturePreset:
+    """Test cases for the preset collection step."""
+
+    @patch(
+        "fastapi_fastkit.backend.interactive.config_builder.prompt_architecture_preset"
+    )
+    def test_collect_architecture_preset_persists_choice(self, mock_preset) -> None:
+        """The preset is persisted on the config under ``architecture_preset``."""
+        # given
+        settings = FastkitConfig()
+        builder = InteractiveConfigBuilder(settings)
+        mock_preset.return_value = "classic-layered"
+
+        # when
+        builder._collect_architecture_preset()
+
+        # then
+        assert builder.config["architecture_preset"] == "classic-layered"
+        # The human-readable description must also be persisted so the
+        # confirmation summary can show users what their choice means.
+        assert (
+            builder.config["architecture_preset_description"]
+            == settings.ARCHITECTURE_PRESETS["classic-layered"]
+        )
+        mock_preset.assert_called_once_with(settings)
+
+
 class TestRunInteractiveFlow:
     """Test cases for run_interactive_flow method with mocked prompts."""
 
@@ -248,10 +275,14 @@ class TestRunInteractiveFlow:
     @patch(
         "fastapi_fastkit.backend.interactive.config_builder.prompt_template_selection"
     )
+    @patch(
+        "fastapi_fastkit.backend.interactive.config_builder.prompt_architecture_preset"
+    )
     @patch("fastapi_fastkit.backend.interactive.config_builder.prompt_basic_info")
     def test_run_interactive_flow_full_journey(
         self,
         mock_basic_info,
+        mock_preset,
         mock_template,
         mock_features,
         mock_validate,
@@ -268,6 +299,7 @@ class TestRunInteractiveFlow:
             "author_email": "test@example.com",
             "description": "Test description",
         }
+        mock_preset.return_value = "domain-starter"
         mock_template.return_value = None  # Empty template
         mock_features.return_value = {
             "database": {"type": "PostgreSQL", "packages": ["sqlalchemy", "asyncpg"]},
@@ -292,6 +324,7 @@ class TestRunInteractiveFlow:
         assert config["project_name"] == "test-project"
         assert config["author"] == "Test Author"
         assert config["authentication"] == "JWT"
+        assert config["architecture_preset"] == "domain-starter"
         assert "all_dependencies" in config
 
     @patch("fastapi_fastkit.backend.interactive.config_builder.confirm_selections")
@@ -304,10 +337,14 @@ class TestRunInteractiveFlow:
     @patch(
         "fastapi_fastkit.backend.interactive.config_builder.prompt_template_selection"
     )
+    @patch(
+        "fastapi_fastkit.backend.interactive.config_builder.prompt_architecture_preset"
+    )
     @patch("fastapi_fastkit.backend.interactive.config_builder.prompt_basic_info")
     def test_run_interactive_flow_user_cancels(
         self,
         mock_basic_info,
+        mock_preset,
         mock_template,
         mock_features,
         mock_validate,
@@ -324,6 +361,7 @@ class TestRunInteractiveFlow:
             "author_email": "test@example.com",
             "description": "Test",
         }
+        mock_preset.return_value = "domain-starter"
         mock_template.return_value = None
         mock_features.return_value = {
             "database": {"type": "None"},
@@ -356,10 +394,14 @@ class TestRunInteractiveFlow:
     @patch(
         "fastapi_fastkit.backend.interactive.config_builder.prompt_template_selection"
     )
+    @patch(
+        "fastapi_fastkit.backend.interactive.config_builder.prompt_architecture_preset"
+    )
     @patch("fastapi_fastkit.backend.interactive.config_builder.prompt_basic_info")
     def test_run_interactive_flow_with_warnings(
         self,
         mock_basic_info,
+        mock_preset,
         mock_template,
         mock_features,
         mock_validate,
@@ -376,6 +418,7 @@ class TestRunInteractiveFlow:
             "author_email": "test@example.com",
             "description": "Test",
         }
+        mock_preset.return_value = "minimal"
         mock_template.return_value = None
         mock_features.return_value = {
             "database": {"type": "None"},

--- a/tests/test_backends/test_interactive_prompts.py
+++ b/tests/test_backends/test_interactive_prompts.py
@@ -39,6 +39,93 @@ class TestPromptBasicInfo:
         assert result["description"] == "A test description"
 
 
+class TestPromptArchitecturePreset:
+    """Test cases for prompt_architecture_preset function."""
+
+    @patch("fastapi_fastkit.backend.interactive.prompts.click.prompt")
+    @patch("fastapi_fastkit.backend.interactive.prompts.render_selection_table")
+    def test_prompt_architecture_preset_default_is_domain_starter(
+        self, mock_render, mock_prompt
+    ) -> None:
+        """Default selection (Enter on the prompt) yields the documented default."""
+        # given
+        settings = FastkitConfig()
+        # Returning the default index simulates the user pressing Enter.
+        preset_ids = list(settings.ARCHITECTURE_PRESETS.keys())
+        default_idx = preset_ids.index(settings.DEFAULT_ARCHITECTURE_PRESET) + 1
+        mock_prompt.return_value = default_idx
+
+        # when
+        result = prompts.prompt_architecture_preset(settings)
+
+        # then
+        assert result == settings.DEFAULT_ARCHITECTURE_PRESET == "domain-starter"
+        # The settings catalog and the prompt's offered options must agree.
+        mock_render.assert_called_once()
+        rendered_options = mock_render.call_args.args[1]
+        assert list(rendered_options.keys()) == preset_ids
+
+    @patch("fastapi_fastkit.backend.interactive.prompts.click.prompt")
+    @patch("fastapi_fastkit.backend.interactive.prompts.render_selection_table")
+    def test_prompt_architecture_preset_explicit_minimal(
+        self, mock_render, mock_prompt
+    ) -> None:
+        """Selecting the first option returns ``minimal``."""
+        # given
+        settings = FastkitConfig()
+        mock_prompt.return_value = 1
+
+        # when
+        result = prompts.prompt_architecture_preset(settings)
+
+        # then
+        assert result == "minimal"
+
+    @patch("fastapi_fastkit.backend.interactive.prompts.click.prompt")
+    @patch("fastapi_fastkit.backend.interactive.prompts.render_selection_table")
+    def test_prompt_architecture_preset_offers_all_required_ids(
+        self, mock_render, mock_prompt
+    ) -> None:
+        """All four preset ids required by issue #44 must be offered."""
+        # given
+        settings = FastkitConfig()
+        mock_prompt.return_value = 1
+
+        # when
+        prompts.prompt_architecture_preset(settings)
+
+        # then
+        offered = set(mock_render.call_args.args[1].keys())
+        assert offered == {
+            "minimal",
+            "single-module",
+            "classic-layered",
+            "domain-starter",
+        }
+
+    @patch("fastapi_fastkit.backend.interactive.prompts.click.prompt")
+    @patch("fastapi_fastkit.backend.interactive.prompts.render_selection_table")
+    def test_prompt_architecture_preset_marks_recommended_default(
+        self, mock_render, mock_prompt
+    ) -> None:
+        """Default preset's row must be visibly annotated as recommended."""
+        # given
+        settings = FastkitConfig()
+        mock_prompt.return_value = 1
+
+        # when
+        prompts.prompt_architecture_preset(settings)
+
+        # then — only the default's display description carries the marker.
+        rendered_options = mock_render.call_args.args[1]
+        default_id = settings.DEFAULT_ARCHITECTURE_PRESET
+        assert "recommended default" in rendered_options[default_id].lower()
+        for preset_id, description in rendered_options.items():
+            if preset_id == default_id:
+                continue
+            assert "recommended default" not in description.lower()
+
+
 class TestPromptTemplateSelection:
     """Test cases for prompt_template_selection function."""
 

--- a/tests/test_backends/test_interactive_selectors.py
+++ b/tests/test_backends/test_interactive_selectors.py
@@ -208,6 +208,95 @@ class TestConfirmSelections:
         # then
         assert result is False
 
+    @patch("fastapi_fastkit.backend.interactive.selectors.console.input")
+    @patch("fastapi_fastkit.backend.interactive.selectors.console.print")
+    def test_confirm_selections_includes_architecture_preset(
+        self, mock_print, mock_input
+    ) -> None:
+        """The summary table must surface the chosen architecture preset.
+
+        It renders ``<id> — <description>`` so users see what their choice
+        means rather than just the raw id.
+        """
+        # given
+        config = {
+            "project_name": "test-project",
+            "author": "Test",
+            "author_email": "test@example.com",
+            "description": "Test",
+            "architecture_preset": "domain-starter",
+            "architecture_preset_description": (
+                "Domain-oriented: src/app/domains/<concept>/."
+            ),
+            "database": {"type": "None"},
+            "authentication": "None",
+            "package_manager": "uv",
+            "all_dependencies": [],
+        }
+        mock_input.return_value = "y"
+
+        # when
+        confirm_selections(config)
+
+        # then — locate the summary Table among the print calls and look
+        # for an "Architecture Preset" row carrying the chosen value plus
+        # its description.
+        from rich.table import Table
+
+        summary_tables = [
+            call.args[0]
+            for call in mock_print.call_args_list
+            if call.args and isinstance(call.args[0], Table)
+        ]
+        assert summary_tables, "Expected a summary Table to be printed"
+
+        # ``rich.table.Table.rows`` doesn't surface cell text directly, so
+        # walk each column's ``cells`` iterable instead.
+        flattened_cells: list[str] = []
+        for table in summary_tables:
+            for column in table.columns:
+                flattened_cells.extend(str(cell) for cell in column.cells)
+        assert "Architecture Preset" in flattened_cells
+        # The id and the em-dash separated description must both render in
+        # one cell so users get the human-readable label, not just the raw id.
+        assert any(
+            cell.startswith("domain-starter — ") for cell in flattened_cells
+        ), f"Expected 'domain-starter — ...' cell; got {flattened_cells}"
+
+    @patch("fastapi_fastkit.backend.interactive.selectors.console.input")
+    @patch("fastapi_fastkit.backend.interactive.selectors.console.print")
+    def test_confirm_selections_falls_back_to_id_when_description_missing(
+        self, mock_print, mock_input
+    ) -> None:
+        """Older configs without a description still render the preset id."""
+        # given
+        config = {
+            "project_name": "legacy",
+            "architecture_preset": "minimal",
+            "database": {"type": "None"},
+            "authentication": "None",
+            "package_manager": "uv",
+            "all_dependencies": [],
+        }
+        mock_input.return_value = "y"
+
+        # when
+        confirm_selections(config)
+
+        # then
+        from rich.table import Table
+
+        summary_tables = [
+            call.args[0]
+            for call in mock_print.call_args_list
+            if call.args and isinstance(call.args[0], Table)
+        ]
+        flattened_cells: list[str] = []
+        for table in summary_tables:
+            for column in table.columns:
+                flattened_cells.extend(str(cell) for cell in column.cells)
+        assert "minimal" in flattened_cells
+
 
 class TestDisplayFeatureCatalog:
     """Test cases for display_feature_catalog function."""

--- a/tests/test_cli_operations/test_cli_interactive_integration.py
+++ b/tests/test_cli_operations/test_cli_interactive_integration.py
@@ -41,6 +41,32 @@ class TestCLIInteractiveMode:
             or "catalog" in output_lower
         )
 
+    def test_init_help_mentions_architecture_preset(self, temp_dir: str) -> None:
+        """``fastkit init --help`` must call out the new preset step.
+
+        Regression guard for issue #44's "docs/help text reflect the new
+        step" acceptance criterion — keeps the user-facing help in sync
+        with the actual interactive flow.
+        """
+        # given / when
+        result = self.runner.invoke(fastkit_cli, ["init", "--help"])
+
+        # then
+        assert result.exit_code == 0
+        text = result.output.lower()
+        assert "architecture preset" in text or "architecture" in text
+        # The four canonical preset ids must all be discoverable from --help.
+        for preset_id in (
+            "minimal",
+            "single-module",
+            "classic-layered",
+            "domain-starter",
+        ):
+            assert preset_id in text, (
+                f"expected preset id {preset_id!r} in init --help output, "
+                f"got:\n{result.output}"
+            )
+
     def test_init_interactive_command_exists(self, temp_dir: str) -> None:
         """Test that init --interactive command is recognized."""
         # given
@@ -96,6 +122,7 @@ class TestCLIInteractiveMode:
                     author,
                     author_email,
                     description,
+                    "",  # Architecture preset: accept default (domain-starter)
                     # Template selection removed - always Empty project
                     "1",  # Database: PostgreSQL (1st option)
                     "1",  # Authentication: JWT (1st option)
@@ -253,6 +280,7 @@ class TestCLIInteractiveMode:
                     "Failure Test",
                     "failure@test.com",
                     "Triggers interactive cleanup branch",
+                    "",  # Architecture preset: accept default (domain-starter)
                     "1",  # Database: PostgreSQL
                     "1",  # Authentication: JWT
                     "1",  # Background Tasks: Celery


### PR DESCRIPTION
# Requesting Merging

## Description

Part of #41  
Closes #44

This PR adds an `Architecture Preset` step to `fastkit init --interactive` so users can choose a project layout before selecting stack features.

The new step is placed early in the interactive flow, persists the selected preset in the generated configuration, shows it in the final confirmation summary, and updates user-facing help/docs so the new flow is clearly explained.

## Type of Change

- [ ] BUG FIX
- [ ] ADDING NEW TEMPLATE
- [x] FEATURE ADDED/UPDATED
- [ ] HOTFIX
- [ ] DELETING UNNECESSARY FEATURES
- [x] DOCUMENTATION & DEVOPS
- [ ] Etc..


## Test Environment

- Local macOS (Apple Silicon / M1), zsh
- Python via `uv`
- Verified command:
  - `uv run pytest tests/test_backends/test_interactive_prompts.py tests/test_backends/test_interactive_config_builder.py tests/test_backends/test_interactive_selectors.py tests/test_cli_operations/test_cli_interactive_integration.py -q`
  - Result: `48 passed`

## Major Changes

- Added a new `Architecture Preset` prompt to interactive init
  - Runs immediately after basic project information
  - Supports:
    - `minimal`
    - `single-module`
    - `classic-layered`
    - `domain-starter`
  - Uses `domain-starter` as the recommended default

- Added architecture preset catalog/settings
  - Introduced `ARCHITECTURE_PRESETS`
  - Introduced `DEFAULT_ARCHITECTURE_PRESET`

- Persisted preset selection in interactive config
  - Stores the canonical preset id in `architecture_preset`
  - Stores the human-readable description in `architecture_preset_description`

- Improved confirmation summary output
  - The final summary now shows the chosen architecture preset
  - Renders both the preset id and its description so the choice is easier to understand

- Improved prompt UX for the new step
  - Marks the default preset as the recommended default in the rendered selection table
  - Updates the prompt text to make the default choice explicit

- Updated CLI help and docs to reflect the new step
  - Updated `fastkit init --help`
  - Updated interactive-mode examples in:
    - `docs/en/index.md`
    - `docs/ko/index.md`
    - `docs/en/reference/faq.md`

- Added regression coverage for the new flow
  - Prompt tests for default selection, explicit selection, required preset ids, and recommended-default annotation
  - Config builder tests for preset persistence through the interactive flow
  - Summary tests for preset rendering and backward-compatible fallback behavior
  - CLI integration tests for interactive input flow and help output

## Screenshots (optional)

N/A

## Etc

- This PR adds the selection/config/help/documentation layer for architecture presets.
- Preset-specific generation behavior is intentionally left for follow-up work in `#45`.
- The default preset for v1.3.0 is `domain-starter`.